### PR TITLE
brsi-tests: Fixed some compilation errors

### DIFF
--- a/src/brs-edk2-test/brsi-tests/BrsBootServices/BlackBoxTest/BrsBootServicesBBTestFunction.c
+++ b/src/brs-edk2-test/brsi-tests/BrsBootServices/BlackBoxTest/BrsBootServicesBBTestFunction.c
@@ -111,7 +111,7 @@ BBTestMemoryMapTest (
   Status = gtBS->HandleProtocol (
               SupportHandle,
               &gEfiStandardTestLibraryGuid,
-              &StandardLib
+              (void**)&StandardLib
               );
   if (EFI_ERROR (Status)) {
     return Status;
@@ -276,7 +276,6 @@ BBTestAcpiTableTest (
   UINTN                               IStatus;
   EFI_ACPI_2_0_ROOT_SYSTEM_DESCRIPTION_POINTER     *AcpiTable;
   UINT8                               Checksum;
-  UINT32                              i;
 
   //
   // Get the Standard Library Interface
@@ -284,7 +283,7 @@ BBTestAcpiTableTest (
   Status = gtBS->HandleProtocol (
               SupportHandle,
               &gEfiStandardTestLibraryGuid,
-              &StandardLib
+              (VOID**)&StandardLib
               );
   if (EFI_ERROR (Status)) {
     return Status;
@@ -295,7 +294,7 @@ BBTestAcpiTableTest (
   //
   Status = SctGetSystemConfigurationTable (
               &gEfiAcpi20TableGuid,
-              &AcpiTable
+              (VOID**)&AcpiTable
               );
   if (EFI_ERROR (Status)){
     StandardLib->RecordAssertion (
@@ -439,7 +438,7 @@ BBTestSmbiosTableTest (
   Status = gtBS->HandleProtocol (
               SupportHandle,
               &gEfiStandardTestLibraryGuid,
-              &StandardLib
+              (VOID**)&StandardLib
               );
   if (EFI_ERROR (Status)) {
     return Status;
@@ -450,7 +449,7 @@ BBTestSmbiosTableTest (
   //
   Status = SctGetSystemConfigurationTable (
               &gEfiSmbios3TableGuid,
-              &SmbiosTable
+              (VOID**)&SmbiosTable
               );
   if (EFI_ERROR(Status)) {
     StandardLib->RecordAssertion (

--- a/src/brs-edk2-test/brsi-tests/BrsiRuntimeServices/BlackBoxTest/BRSIRuntimeServicesBBTestFunction.c
+++ b/src/brs-edk2-test/brsi-tests/BrsiRuntimeServices/BlackBoxTest/BRSIRuntimeServicesBBTestFunction.c
@@ -436,7 +436,7 @@ BBTestNonVolatileVariable (
     Status = gtRT->SetVariable (
                 TEST_VAR_NAME,
                 &VarVendorGuid,
-                NULL,
+                0,
                 Size,
                 NULL
                 );
@@ -537,7 +537,7 @@ BBTestNonVolatileVariable (
     Status = gtRT->SetVariable (
                 TEST_VAR_NAME,
                 &VarVendorGuid,
-                NULL,
+                0,
                 Size,
                 NULL
                 );


### PR DESCRIPTION
I tried compiling and found some errors related to type mismatches and unused variables. This patch fixes these issues.

```sh
/home/merle/workspaces/riscv-brs-tests/src/brs-edk2-test/edk2-test/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/BrsiRuntimeServices/BlackBoxTest/BRSIRuntimeServicesBBTestFunction.c: In function ‘BBTestNonVolatileVariable’:
/home/merle/workspaces/riscv-brs-tests/src/brs-edk2-test/edk2-test/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/BrsiRuntimeServices/BlackBoxTest/BRSIRuntimeServicesBBTestFunction.c:439:17: error: passing argument 3 of ‘gtRT->SetVariable’ makes integer from pointer without a cast [-Wint-conversion]
  439 |                 NULL,
      |                 ^~~~~
      |                 |
      |                 void *
/home/merle/workspaces/riscv-brs-tests/src/brs-edk2-test/edk2-test/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/BrsiRuntimeServices/BlackBoxTest/BRSIRuntimeServicesBBTestFunction.c:439:17: note: expected ‘UINT32’ {aka ‘unsigned int’} but argument is of type ‘void *’
Building ... /home/merle/workspaces/riscv-brs-tests/src/brs-edk2-test/edk2-test/uefi-sct/SctPkg/TestCase/RIVL/BootService/BootServiceENTSTest.inf [RISCV64]
/home/merle/workspaces/riscv-brs-tests/src/brs-edk2-test/edk2-test/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/BrsiRuntimeServices/BlackBoxTest/BRSIRuntimeServicesBBTestFunction.c:540:17: error: passing argument 3 of ‘gtRT->SetVariable’ makes integer from pointer without a cast [-Wint-conversion]
  540 |                 NULL,
      |                 ^~~~~
      |                 |
      |                 void *

/home/merle/workspaces/riscv-brs-tests/src/brs-edk2-test/edk2-test/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/BrsBootServices/BlackBoxTest/BrsBootServicesBBTestFunction.c: In function ‘BBTestMemoryMapTest’:
/home/merle/workspaces/riscv-brs-tests/src/brs-edk2-test/edk2-test/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/BrsBootServices/BlackBoxTest/BrsBootServicesBBTestFunction.c:114:15: error: passing argument 3 of ‘gtBS->HandleProtocol’ from incompatible pointer type [-Wincompatible-pointer-types]
  114 |               &StandardLib
      |               ^~~~~~~~~~~~
      |               |
      |               EFI_STANDARD_TEST_LIBRARY_PROTOCOL ** {aka struct _EFI_STANDARD_TEST_LIBRARY_PROTOCOL **}
/home/merle/workspaces/riscv-brs-tests/src/brs-edk2-test/edk2-test/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/BrsBootServices/BlackBoxTest/BrsBootServicesBBTestFunction.c:114:15: note: expected ‘void **’ but argument is of type ‘EFI_STANDARD_TEST_LIBRARY_PROTOCOL **’ {aka ‘struct _EFI_STANDARD_TEST_LIBRARY_PROTOCOL **’}
/home/merle/workspaces/riscv-brs-tests/src/brs-edk2-test/edk2-test/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/BrsBootServices/BlackBoxTest/BrsBootServicesBBTestFunction.c: In function ‘BBTestAcpiTableTest’:
/home/merle/workspaces/riscv-brs-tests/src/brs-edk2-test/edk2-test/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/BrsBootServices/BlackBoxTest/BrsBootServicesBBTestFunction.c:287:15: error: passing argument 3 of ‘gtBS->HandleProtocol’ from incompatible pointer type [-Wincompatible-pointer-types]
  287 |               &StandardLib
      |               ^~~~~~~~~~~~
      |               |
      |               EFI_STANDARD_TEST_LIBRARY_PROTOCOL ** {aka struct _EFI_STANDARD_TEST_LIBRARY_PROTOCOL **}
/home/merle/workspaces/riscv-brs-tests/src/brs-edk2-test/edk2-test/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/BrsBootServices/BlackBoxTest/BrsBootServicesBBTestFunction.c:287:15: note: expected ‘void **’ but argument is of type ‘EFI_STANDARD_TEST_LIBRARY_PROTOCOL **’ {aka ‘struct _EFI_STANDARD_TEST_LIBRARY_PROTOCOL **’}
/home/merle/workspaces/riscv-brs-tests/src/brs-edk2-test/edk2-test/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/BrsBootServices/BlackBoxTest/BrsBootServicesBBTestFunction.c:298:15: error: passing argument 2 of ‘SctGetSystemConfigurationTable’ from incompatible pointer type [-Wincompatible-pointer-types]
  298 |               &AcpiTable
      |               ^~~~~~~~~~
      |               |
      |               EFI_ACPI_2_0_ROOT_SYSTEM_DESCRIPTION_POINTER **
In file included from /home/merle/workspaces/riscv-brs-tests/src/brs-edk2-test/edk2-test/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/BrsBootServices/BlackBoxTest/BrsBootServicesBBTestFunction.c:37:
/home/merle/workspaces/riscv-brs-tests/src/brs-edk2-test/edk2-test/uefi-sct/SctPkg/Include/SctLib.h:595:10: note: expected ‘void **’ but argument is of type ‘EFI_ACPI_2_0_ROOT_SYSTEM_DESCRIPTION_POINTER **’
  595 |   IN OUT VOID                       **Table
      |   ~~~~~~~^~~~~
/home/merle/workspaces/riscv-brs-tests/src/brs-edk2-test/edk2-test/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/BrsBootServices/BlackBoxTest/BrsBootServicesBBTestFunction.c:279:10: warning: unused variable ‘i’ [-Wunused-variable]
  279 |   UINT32                              i;
      |          ^
/home/merle/workspaces/riscv-brs-tests/src/brs-edk2-test/edk2-test/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/BrsBootServices/BlackBoxTest/BrsBootServicesBBTestFunction.c: In function ‘BBTestSmbiosTableTest’:
/home/merle/workspaces/riscv-brs-tests/src/brs-edk2-test/edk2-test/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/BrsBootServices/BlackBoxTest/BrsBootServicesBBTestFunction.c:442:15: error: passing argument 3 of ‘gtBS->HandleProtocol’ from incompatible pointer type [-Wincompatible-pointer-types]
  442 |               &StandardLib
      |               ^~~~~~~~~~~~
      |               |
      |               EFI_STANDARD_TEST_LIBRARY_PROTOCOL ** {aka struct _EFI_STANDARD_TEST_LIBRARY_PROTOCOL **}
/home/merle/workspaces/riscv-brs-tests/src/brs-edk2-test/edk2-test/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/BrsBootServices/BlackBoxTest/BrsBootServicesBBTestFunction.c:442:15: note: expected ‘void **’ but argument is of type ‘EFI_STANDARD_TEST_LIBRARY_PROTOCOL **’ {aka ‘struct _EFI_STANDARD_TEST_LIBRARY_PROTOCOL **’}
/home/merle/workspaces/riscv-brs-tests/src/brs-edk2-test/edk2-test/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/BrsBootServices/BlackBoxTest/BrsBootServicesBBTestFunction.c:453:15: error: passing argument 2 of ‘SctGetSystemConfigurationTable’ from incompatible pointer type [-Wincompatible-pointer-types]
  453 |               &SmbiosTable
      |               ^~~~~~~~~~~~
      |               |
      |               SMBIOS_TABLE_3_0_ENTRY_POINT **
/home/merle/workspaces/riscv-brs-tests/src/brs-edk2-test/edk2-test/uefi-sct/SctPkg/Include/SctLib.h:595:10: note: expected ‘void **’ but argument is of type ‘SMBIOS_TABLE_3_0_ENTRY_POINT **’
  595 |   IN OUT VOID                       **Table
      |   ~~~~~~~^~~~~
/home/merle/workspaces/riscv-brs-tests/src/brs-edk2-test/edk2-test/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/BrsBootServices/BlackBoxTest/BrsBootServicesBBTestFunction.c:434:10: warning: unused variable ‘i’ [-Wunused-variable]
  434 |   UINT32                              i;
      |          ^
```